### PR TITLE
Updated Line 79 for error handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -76,7 +76,7 @@ def decrypt():
     #format to display
     decodetext = ''
     for clear in clearHex: 
-        decodetext += bytearray.fromhex(clear).decode()
+        decodetext += bytearray.fromhex(clear).decode(errors='backslashreplace').replace('\\xda', '<br>')
     return render_template('index.html', cleartext = decodetext)
 
 #run


### PR DESCRIPTION
Any ciphertext that is encrypted from plaintext with multiple lines, i.e.:

two
lines

would throw a UnicodeDecodeError when running the decode() on it. Updated code handles that issue and also replaces the characters to properly display on the website. The index.html change needs to update as well for this to properly function.